### PR TITLE
Handle other http status code

### DIFF
--- a/prerender-parse.js
+++ b/prerender-parse.js
@@ -18,7 +18,11 @@ var parseAdaptor = module.exports = function(Parse) {
       error: function(res) {
         console.error('Request failed with code ' + res.status);
         console.error(res);
-        callback(null);
+        
+        res.body = res.text;
+        res.statusCode = res.status;
+
+        callback(res);
       }
     });
   };


### PR DESCRIPTION
Prerender.io allows the app to ask prerender to send different status code, like 404 or 301,
see https://prerender.io/documentation/best-practices
This fix handle this case.